### PR TITLE
Add support for multi-project source files

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,25 +4,23 @@ const { filterBlock, filterFrame } = require('./utils.js');
 
 export const DittoContext = createContext({})
 
-const useDittoSingleText = (textId) => {
+const useDittoSingleText = ({ projectId, textId }) => {
   const copy = useContext(DittoContext);
 
-  for (const projectId in copy.projects) {
-    const project = copy.projects[projectId];
+  const project = copy.projects[projectId];
 
-    for (const frameId in project.frames) {
-      const frame = project.frames[frameId];
+  for (const frameId in project.frames) {
+    const frame = project.frames[frameId];
 
-      for (const blockId in frame.blocks) {
-        const block = frame.blocks[blockId];
+    for (const blockId in frame.blocks) {
+      const block = frame.blocks[blockId];
 
-        if (textId in block) 
-          return block[textId].text
-      }
-
-      if (frame.otherText && textId in frame.otherText) 
-        return frame.otherText[textId].text
+      if (textId in block) 
+        return block[textId].text
     }
+
+    if (frame.otherText && textId in frame.otherText) 
+      return frame.otherText[textId].text
   }
 
   console.error(`[Text not found in Ditto project with ID: [${textId}]]`)
@@ -79,8 +77,8 @@ const DittoDefault = (props) => {
 };
 
 const DittoText = (props) => {
-  const { textId } = props;
-  const text = useDittoSingleText(textId)
+  const { projectId, textId } = props;
+  const text = useDittoSingleText({ projectId, textId });
 
   return (
     <React.Fragment>
@@ -100,6 +98,11 @@ function getDittoType(props) {
 }
 
 export const Ditto = (props) => {
+  if (!props.projectId) {
+    console.error("No Project ID provided to Ditto component.");
+    return <React.Fragment />;
+  }
+
   const type = getDittoType(props);
 
   switch (type) {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,9 +4,20 @@ const { filterBlock, filterFrame } = require('./utils.js');
 
 export const DittoContext = createContext({})
 
+const error = (message, returnValue = message) => {
+  console.error(message);
+  return returnValue;
+};
+
+const nullError = (message) => error(message, null);
+const fragmentError = (message) => error(message, <React.Fragment />);
+
 const useDittoSingleText = ({ projectId, textId }) => {
   const copy = useContext(DittoContext);
 
+  if (!projectId) 
+    return error('No Project ID provided.');
+  
   const project = copy.projects[projectId];
 
   for (const frameId in project.frames) {
@@ -23,26 +34,25 @@ const useDittoSingleText = ({ projectId, textId }) => {
       return frame.otherText[textId].text
   }
 
-  console.error(`[Text not found in Ditto project with ID: [${textId}]]`)
-  return `[Text not found in Ditto project with ID: [${textId}]]`
+  return error(`[Text not found in Ditto project with ID: [${textId}]]`);
 }
 
 const useDitto = ({ projectId, frameId, blockId, filters }) => {
-  const copy = useContext(DittoContext)
+  const copy = useContext(DittoContext);
 
   if (!copy.projects) 
-    return console.error('Source JSON for DittoProvider does not have projects.');
+    return nullError('Source JSON for DittoProvider does not have projects.');
 
   if (!projectId) 
-    return console.error('No Project ID provided.');
+    return nullError('No Project ID provided.');
 
   const project = copy.projects[projectId];
 
   if (!frameId) {
-    return console.error('No Frame ID provided.');
+    return nullError('No Frame ID provided.');
   }
   if (!(frameId in project.frames)) 
-    return console.error(`Frame of ID [${frameId}] not found in this Ditto project.`);
+    return nullError(`Frame of ID [${frameId}] not found in this Ditto project.`);
 
   const frame = project.frames[frameId];
 
@@ -50,9 +60,7 @@ const useDitto = ({ projectId, frameId, blockId, filters }) => {
     return filterFrame(frame, filters);
 
   if (!(blockId in frame.blocks)) 
-    return console.error(
-      `Block of ID [${blockId}] not found in frame of ID [${frameId}] in this Ditto project.`
-    );
+    return nullError(`Block of ID [${blockId}] not found in frame of ID [${frameId}] in this Ditto project.`);
   
   const block = frame.blocks[blockId];
   
@@ -68,10 +76,8 @@ const DittoDefault = (props) => {
   if (!data)
     return <React.Fragment />;
 
-  if (!childIsFunction) {
-    console.error(`Please provide either a textId or function child to your Ditto component.`);
-    return <React.Fragment />;
-  }
+  if (!childIsFunction) 
+    return fragmentError(`Please provide either a textId or function child to your Ditto component.`);
 
   return props.children(data);
 };
@@ -98,10 +104,8 @@ function getDittoType(props) {
 }
 
 export const Ditto = (props) => {
-  if (!props.projectId) {
-    console.error("No Project ID provided to Ditto component.");
-    return <React.Fragment />;
-  }
+  if (!props.projectId) 
+    return fragmentError('No Project ID provided to Ditto component.');
 
   const type = getDittoType(props);
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -16,7 +16,7 @@ const useDittoSingleText = ({ projectId, textId }) => {
   const copy = useContext(DittoContext);
 
   if (!projectId) 
-    return error('No Project ID provided.');
+    return nullError('No Project ID provided.');
   
   const project = copy.projects[projectId];
 


### PR DESCRIPTION
**Associated PRs**: 
- https://github.com/dittowords/ditto-app/pull/394
- https://github.com/dittowords/cli/pull/15

## Overview
<!--- What does this PR do? --->
This PR:
- adds support to the React SDK for consuming multi-project `text.json` files
- adds support for passing a `projectId` prop to `<Ditto />` components 
- iterates on cleaning up and decomposing some of the components and hooks

## Context
<!--- Any context about why you are creating this PR? Notion doc, screenshot, conversation, etc. --->
Developers using our CLI currently have to `cd` into subdirectories and `pull` multiple times when they have more than one Ditto project associated with a code repository they're working in. Adding the ability to `pull` multiple Ditto projects into a single `text.json` file in the root of the project will:
- cut down manual actions by forcing developers to `pull` only once
- save time by enabling developers to search through a single file when looking for text snippets or frame ids

This [Notion doc](https://www.notion.so/dittov3/Pulling-Multiple-Files-via-CLI-3437c51c811844e1a1a579bf23d3e5e8) contains the spec and additional details.