### PR TITLE
Bump package version to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ditto-react",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "React SDK for using product copy from Ditto in development.",
   "author": "Ditto Tech Inc.",
   "license": "MIT",


### PR DESCRIPTION
Since https://github.com/dittowords/ditto-react/pull/2 has now been merged, we need to bump the `version` in `package.json` to publish the latest changes to NPM.