### PR TITLE
[DIT-502] Type safety, `children` render prop, export individual components

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,16 +1,22 @@
-import DittoProvider, { Ditto } from "ditto-react";
-import { useState } from "react";
+import DittoProvider, {
+  Ditto,
+  Frame,
+  Block,
+  DittoText,
+  DittoFrame,
+  DittoBlock,
+  DittoComponent,
+} from "ditto-react";
 import source from "./ditto";
 
-const options = Object.keys(source);
-
 const App = () => {
-  const [variant, setVariant] = useState("base");
-
   return (
     <div style={{ padding: 40 }}>
       <div>
-        <DittoProvider source={source}>
+        <DittoProvider
+          source={source}
+          projectId="project_606cb89ac55041013d662f8b"
+        >
           <h4>Component Library</h4>
           <ul>
             <li>
@@ -22,75 +28,97 @@ const App = () => {
             <li>
               <Ditto componentId="excellent.validation" />
             </li>
+            <li>
+              <Ditto componentId="excellent.validation" />
+            </li>
+            <li>
+              <Ditto componentId="excellent.validation">
+                {(text: string) => <>{text}</>}
+              </Ditto>
+            </li>
+            <li>
+              <DittoComponent componentId="excellent.validation">
+                {(text) => <>{text}</>}
+              </DittoComponent>
+            </li>
           </ul>
           <h4>Project</h4>
           <ul>
             <li>
-              <Ditto
-                textId="text_606cb89a2e11c4009984ad74"
-                projectId="project_606cb89ac55041013d662f8b"
-              />
-            </li>
-            <li>
-              <Ditto
-                textId="text_606cb89a2e11c4009984ad75"
-                projectId="project_606cb89ac55041013d662f8b"
-              />
-            </li>
-            <li>
-              <Ditto
-                textId="text_606cb89a2e11c4009984ad76"
-                projectId="project_606cb89ac55041013d662f8b"
-              />
-            </li>
-          </ul>
-        </DittoProvider>
-      </div>
-      <br />
-      <hr />
-      <div>
-        <div style={{ padding: "20px 0" }}>
-          <label htmlFor="">Variant</label> <br />
-          <select
-            onChange={(e) => {
-              setVariant(e.target.value);
-            }}
-            value={variant}
-          >
-            {options.map((option) => (
-              <option value={option} key={option}>
-                {option}
-              </option>
-            ))}
-          </select>
-        </div>
-        <DittoProvider
-          source={source}
-          variant={variant}
-          projectId="project_606cb89ac55041013d662f8b"
-        >
-          <h4>Component Library w/ Variants</h4>
-          <ul>
-            <li>
-              <Ditto componentId="basic-plan-team-disclaimer" />
-            </li>
-            <li>
-              <Ditto componentId="best-practices.error.incorrect-date" />
-            </li>
-            <li>
-              <Ditto componentId="excellent.validation" />
-            </li>
-          </ul>
-          <h4>Project w/ Variants</h4>
-          <ul>
-            <li>
-              <Ditto textId="text_606cb89a2e11c4009984ad74" />
-            </li>
-            <li>
               <Ditto textId="text_606cb89a2e11c4009984ad75" />
             </li>
             <li>
-              <Ditto textId="text_606cb89a2e11c4009984ad76" />
+              <Ditto textId="text_606cb89a2e11c4009984ad75">
+                {(text: string) => <>{text}</>}
+              </Ditto>
+            </li>
+            <li>
+              <DittoText textId="text_606cb89a2e11c4009984ad75">
+                {(text) => <>{text}</>}
+              </DittoText>
+            </li>
+            <li>
+              <Ditto frameId="frame_606cb89a2e11c4009984ad72">
+                {(frame: Frame) => {
+                  const markup: React.ReactNode[] = [];
+
+                  Object.keys(frame.blocks).forEach((blockId) => {
+                    const block: Block = frame.blocks[blockId];
+
+                    Object.keys(block).forEach((textId) => {
+                      markup.push(
+                        <span key={`${blockId}-${textId}`}>
+                          {block[textId]}
+                        </span>
+                      );
+                    });
+                  });
+
+                  return markup;
+                }}
+              </Ditto>
+            </li>
+            <li>
+              <DittoFrame frameId="frame_606cb89a2e11c4009984ad72">
+                {(frame) => {
+                  const markup: React.ReactNode[] = [];
+
+                  Object.keys(frame.blocks).forEach((blockId) => {
+                    const block: Block = frame.blocks[blockId];
+
+                    Object.keys(block).forEach((textId) => {
+                      markup.push(
+                        <span key={`${blockId}-${textId}`}>
+                          {block[textId]}
+                        </span>
+                      );
+                    });
+                  });
+
+                  return markup;
+                }}
+              </DittoFrame>
+            </li>
+            <li>
+              <Ditto frameId="frame_606cb89a2e11c4009984ad72" blockId="heading">
+                {(block: Block) => {
+                  return Object.keys(block).map((key) => (
+                    <span key={key}>{block[key]}</span>
+                  ));
+                }}
+              </Ditto>
+            </li>
+            <li>
+              <DittoBlock
+                frameId="frame_606cb89a2e11c4009984ad72"
+                blockId="heading"
+              >
+                {(block) => {
+                  return Object.keys(block).map((key) => (
+                    <span key={key}>{block[key]}</span>
+                  ));
+                }}
+              </DittoBlock>
             </li>
           </ul>
         </DittoProvider>

--- a/example/src/ditto/config.yml
+++ b/example/src/ditto/config.yml
@@ -3,5 +3,3 @@ projects:
     id: ditto_component_library
   - name: NUX Onboarding
     id: 606cb89ac55041013d662f8b
-variants: true
-format: flat

--- a/src/components/DittoComponent.tsx
+++ b/src/components/DittoComponent.tsx
@@ -1,21 +1,22 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { useDittoComponent } from "../hooks/useDittoComponent";
+import { DittoComponentLibraryProps } from "./Ditto";
 
-export interface DittoComponentProps {
-  componentId: string;
-  children?: (value: string | { name: string; text: string }) => JSX.Element;
-}
-
-export const DittoComponent = (props: DittoComponentProps) => {
+export const DittoComponent = (props: DittoComponentLibraryProps) => {
   const { children, componentId } = props;
   const value = useDittoComponent({
     componentId,
     alwaysReturnString: typeof children !== "function",
   });
 
+  const text = useMemo(
+    () => (typeof value === "object" ? value.text : value),
+    [value]
+  );
+
   return (
     <React.Fragment>
-      {typeof children === "function" ? children(value) : value}
+      {typeof children === "function" ? children(text) : text}
     </React.Fragment>
   );
 };

--- a/src/components/DittoText.tsx
+++ b/src/components/DittoText.tsx
@@ -1,18 +1,14 @@
-import React from 'react';
-import { useDittoSingleText } from '../hooks/useDittoSingleText';
-
-export interface DittoTextProps {
-  projectId: string;
-  textId: string;
-}
+import React from "react";
+import { useDittoSingleText } from "../hooks/useDittoSingleText";
+import { DittoTextProps } from "./Ditto";
 
 export const DittoText = (props: DittoTextProps) => {
-  const { projectId, textId } = props;
+  const { projectId, textId, children } = props;
   const text = useDittoSingleText({ projectId, textId });
 
   return (
     <React.Fragment>
-      {text}
+      {typeof children === "function" ? children(text) : text}
     </React.Fragment>
-  )
-}
+  );
+};

--- a/src/hooks/useDitto.ts
+++ b/src/hooks/useDitto.ts
@@ -8,7 +8,7 @@ import {
 } from "../lib/utils";
 
 interface useDittoProps {
-  projectId: string;
+  projectId?: string;
   frameId: string;
   blockId?: string;
   filters?: {
@@ -18,7 +18,8 @@ interface useDittoProps {
 
 export const useDitto = (props: useDittoProps) => {
   const { projectId, frameId, blockId, filters } = props;
-  const { sourceBase, sourceVariant, variant, options } = useContext(DittoContext);
+  const { sourceBase, sourceVariant, variant, options } =
+    useContext(DittoContext);
 
   if (!sourceBase.projects)
     return nullError("Source JSON for DittoProvider does not have projects.");

--- a/src/hooks/useDittoSingleText.ts
+++ b/src/hooks/useDittoSingleText.ts
@@ -1,18 +1,16 @@
 import { useContext } from "react";
 import { DittoContext } from "../lib/context";
-import {
-  isDefaultFormatProject,
-  nullError,
-} from "../lib/utils";
+import { isDefaultFormatProject, nullError } from "../lib/utils";
 
 interface useDittoSingleTextProps {
-  projectId: string;
+  projectId?: string;
   textId: string;
 }
 
 export const useDittoSingleText = (props: useDittoSingleTextProps) => {
   const { projectId, textId } = props;
-  const { sourceBase, sourceVariant, variant, options } = useContext(DittoContext);
+  const { sourceBase, sourceVariant, variant, options } =
+    useContext(DittoContext);
 
   if (!projectId) return nullError("No Project ID provided.");
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,10 @@
-export { Ditto } from './components/Ditto';
-import { DittoProvider } from './components/DittoProvider';
+export { Ditto } from "./components/Ditto";
+export { Frame, Block } from "./lib/context";
+import { DittoProvider } from "./components/DittoProvider";
+
+export { DittoComponent } from "./components/DittoComponent";
+export { DittoFrame, DittoBlock } from "./components/DittoFrameOrBlock";
+export { DittoText } from "./components/DittoText";
+
+export { DittoProvider };
 export default DittoProvider;

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -5,27 +5,22 @@ interface DittoText {
   tags?: string[];
 }
 
-/**
- * TODO:
- * Standardize differenes between default project format
- * and default component library format (hopefully solved
- * as a side effect of us moving away from the default
- * format completely in a future version)
- */
+export interface Block {
+  [textId: string]: DittoText;
+}
+
+export interface Frame {
+  frameName: string;
+  blocks: {
+    [blockId: string]: Block;
+  };
+  otherText?: Block;
+}
+
 export interface FormatDefaultProject {
   project_id: string;
   frames: {
-    [frameId: string]: {
-      frameName: string;
-      blocks: {
-        [blockId: string]: {
-          [textId: string]: DittoText;
-        };
-      };
-      otherText?: {
-        [textId: string]: DittoText;
-      };
-    };
+    [frameId: string]: Frame;
   };
 }
 

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -3,9 +3,9 @@ import {
   DittoComponentLibraryProps,
   DittoProjectProps,
   DittoProps,
+  DittoFrameOrBlockProps,
+  DittoTextProps,
 } from "../components/Ditto";
-import { DittoFrameOrBlockProps } from "../components/DittoFrameOrBlock";
-import { DittoTextProps } from "../components/DittoText";
 import { FormatDefaultProject, Project } from "./context";
 
 export const filterBlock = (blockObj, filters) => {
@@ -55,7 +55,7 @@ export const isComponentLibrary = (
   props: DittoProps
 ): props is DittoComponentLibraryProps => "componentId" in props;
 
-export const isTextComponent = (props: DittoProps): props is DittoTextProps =>
+export const isText = (props: DittoProps): props is DittoTextProps =>
   "textId" in props;
 
 export const isFrameOrBlockComponent = (


### PR DESCRIPTION
This PR implements all of the following:
- Support passing `children` render prop in all prop configurations on `<Ditto />` component
- Fix a handful of miscellaneous type errors
- Export individual components in addition to the `<Ditto />`-
these components provide stricter type checking and better type
inference out of the box:
>- `<DittoFrame />`
>- `<DittoBlock />`
>- `<DittoText />`
>- `<DittoComponent />`

## Linked Issues
- https://linear.app/dittowords/issue/DIT-502/add-children-render-prop-support-to-ditto-react
- https://github.com/dittowords/ditto-react/issues/7