### PR TITLE
[DIT-1512] Update support for variant plurals/variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ To see a working React app utilizing the [Ditto CLI](https://github.com/dittowor
 
 The `DittoProvider` component should wrap all parts of your component tree that will display copy from Ditto.
 
+If `variant` is supplied, base text values will be used as a fallback for any pieces of text where corresponding variant values can't be found.
+
 #### Props
 
 | Prop        | Type              | Description                                                                                                                                                              |
@@ -152,7 +154,6 @@ The `DittoProvider` component should wrap all parts of your component tree that 
 | `source`    | JSON (required)   | Copy data imported from the CLI-generated `ditto` folder — see [Source](#Source) for more info                                                                           |
 | `variant`   | String (optional) | The API ID of a variant; if specified, all descendant `Ditto` components will attempt to display the value of that variant (requires usage of the `variants` CLI option) |
 | `projectId` | String (optional) | The ID of a project in Ditto; can also be ommitted from the provdier and passed as a direct prop to `Ditto` components                                                   |
-| `options`   | Object (optional) | See [DittoProvider options](#Options)                                                                                                                                    |
 
 #### Example
 
@@ -162,12 +163,6 @@ import source from "./ditto";
 
 <DittoProvider source={source}>{/* the rest of your app */}</DittoProvider>;
 ```
-
-#### Options
-
-| Key           | Type                          | Description                                                                                                                                                                                                                                                             |
-| ------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `environment` | `development` or `production` | The environment the `DittoProvider` should operate in. If `production` or unspecified, missing text will be silently replaced with an empty string. If `development`, missing text will be replaced with clear error strings and errors will be emitted to the console. |
 
 ### Ditto
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import DittoProvider, {
   Ditto,
   Frame,
@@ -10,12 +11,23 @@ import DittoProvider, {
 import source from "./ditto";
 
 const App = () => {
+  const options = ['base', 'french']
+  const [variant, setVariant] = useState<string>('base')
+  const onVariantChange = (e: any) => {
+    setVariant(e.target.value)
+  }
   return (
     <div style={{ padding: 40 }}>
+      <select onChange={onVariantChange}>
+        {options.map(option => (
+          <option key={option} value={option}>{option}</option>
+        ))}
+      </select>
       <div>
         <DittoProvider
           source={source}
           projectId="project_61e72388365c930170607378"
+          variant={variant}
         >
           <h4>Component Libary</h4>
           <div>

--- a/example/src/ditto/base.json
+++ b/example/src/ditto/base.json
@@ -9,6 +9,20 @@
           "otherText": {
             "text_61e7238bbae5dc00fb66de01": {
               "text": "You ordered {{itemCount}} apples",
+              "variants": {
+                "french": {
+                  "text": "Vous avez commandé {{itemCount}} pommes",
+                  "variables": {
+                    "itemCount": {
+                      "example": 10
+                    }
+                  },
+                  "plurals": {
+                    "other": "Vous avez commandé {{itemCount}} pommes",
+                    "one": "Vous avez commandé {{itemCount}} pomme"
+                  }
+                }
+              },
               "status": "REVIEW",
               "variables": {
                 "itemCount": {
@@ -22,6 +36,21 @@
             },
             "text_61e7238bbae5dc00fb66de0b": {
               "text": "There are  {{itemCount}} items in the cart",
+              "variants": {
+                "french": {
+                  "text": "Il y a {{itemCount}} pommes dans le panier",
+                  "variables": {
+                    "itemCount": {
+                      "example": 10
+                    }
+                  },
+                  "plurals": {
+                    "other": "Il y a {{itemCount}} pommes dans le panier",
+                    "one": "il y a {{itemCount}} pomme dans le panier",
+                    "zero": "le panier est vide"
+                  }
+                }
+              },
               "is_comp": true,
               "component_api_id": "shopping-cart",
               "variables": {
@@ -37,6 +66,20 @@
             },
             "text_61e7238bbae5dc00fb66de15": {
               "text": "There are {{itemCount}} puppies",
+              "variants": {
+                "french": {
+                  "text": "Il y a {{itemCount}} chiots",
+                  "variables": {
+                    "itemCount": {
+                      "example": 10
+                    }
+                  },
+                  "plurals": {
+                    "other": "Il y a {{itemCount}} chiots",
+                    "one": "Il y a {{itemCount}} chiot"
+                  }
+                }
+              },
               "variables": {
                 "itemCount": {
                   "example": 10
@@ -54,9 +97,11 @@
           "blocks": {
             "header": {
               "text_61e7238bbae5dc00fb66ddff": {
-                "text": "Welcome!",
+                "text": "Welcome!1",
                 "variants": {
-                  "french": "Bonjour!"
+                  "french": {
+                    "text": "Bonjour!"
+                  }
                 }
               },
               "text_61e7238bbae5dc00fb66de09": {
@@ -94,7 +139,9 @@
             "text_61e7238bbae5dc00fb66de2c": {
               "text": "Next",
               "variants": {
-                "french": "Prochaine"
+                "french": {
+                  "text": "Prochaine"
+                }
               }
             }
           }
@@ -229,6 +276,15 @@
               "text": "<- Back"
             }
           }
+        },
+        "frame_61f02da85e52b60129977c37": {
+          "frameName": "Frame 2",
+          "blocks": {},
+          "otherText": {
+            "text_61f02da85e52b60129977c3b": {
+              "text": "xzcv"
+            }
+          }
         }
       }
     },
@@ -247,6 +303,21 @@
             "other": "There are  {{itemCount}} items in the cart",
             "one": "There is  {{itemCount}} item in the cart",
             "zero": "The cart is empty"
+          },
+          "variants": {
+            "french": {
+              "text": "Il y a {{itemCount}} pommes dans le panier",
+              "variables": {
+                "itemCount": {
+                  "example": 10
+                }
+              },
+              "plurals": {
+                "other": "Il y a {{itemCount}} pommes dans le panier",
+                "one": "il y a {{itemCount}} pomme dans le panier",
+                "zero": "le panier est vide"
+              }
+            }
           }
         },
         "team-plan": {
@@ -256,5 +327,5 @@
       }
     }
   },
-  "exported_at": "2022-01-19T16:29:04.032Z"
+  "exported_at": "2022-06-15T14:03:42.567Z"
 }

--- a/example/src/ditto/config.yml
+++ b/example/src/ditto/config.yml
@@ -2,3 +2,4 @@ projects:
   - name: 'Onboarding Flow'
     id: 61e72388365c930170607378
 components: true
+variants: true

--- a/example/src/ditto/french.json
+++ b/example/src/ditto/french.json
@@ -1,0 +1,91 @@
+{
+  "projects": {
+    "project_61e72388365c930170607378": {
+      "project_id": "61e72388365c930170607378",
+      "frames": {
+        "frame_61e7238bbae5dc00fb66ddf5": {
+          "frameName": "Plurals",
+          "blocks": {},
+          "otherText": {
+            "text_61e7238bbae5dc00fb66de01": {
+              "text": "Vous avez commandé {{itemCount}} pommes",
+              "status": "REVIEW",
+              "variables": {
+                "itemCount": {
+                  "example": 10
+                }
+              },
+              "plurals": {
+                "other": "Vous avez commandé {{itemCount}} pommes",
+                "one": "Vous avez commandé {{itemCount}} pomme"
+              }
+            },
+            "text_61e7238bbae5dc00fb66de0b": {
+              "text": "Il y a {{itemCount}} pommes dans le panier",
+              "is_comp": true,
+              "component_api_id": "shopping-cart",
+              "variables": {
+                "itemCount": {
+                  "example": 10
+                }
+              },
+              "plurals": {
+                "other": "Il y a {{itemCount}} pommes dans le panier",
+                "one": "il y a {{itemCount}} pomme dans le panier",
+                "zero": "le panier est vide"
+              }
+            },
+            "text_61e7238bbae5dc00fb66de15": {
+              "text": "Il y a {{itemCount}} chiots",
+              "variables": {
+                "itemCount": {
+                  "example": 10
+                }
+              },
+              "plurals": {
+                "other": "Il y a {{itemCount}} chiots",
+                "one": "Il y a {{itemCount}} chiot"
+              }
+            }
+          }
+        },
+        "frame_61e7238bbae5dc00fb66ddf1": {
+          "frameName": "Welcome",
+          "blocks": {
+            "header": {
+              "text_61e7238bbae5dc00fb66ddff": {
+                "text": "Bonjour!"
+              }
+            },
+            "cta": {}
+          },
+          "otherText": {
+            "text_61e7238bbae5dc00fb66de2c": {
+              "text": "Prochaine"
+            }
+          }
+        }
+      }
+    },
+    "ditto_component_library": {
+      "project_name": "Ditto Component Library",
+      "components": {
+        "shopping-cart": {
+          "name": "Shopping Cart",
+          "text": "Il y a {{itemCount}} pommes dans le panier",
+          "variables": {
+            "itemCount": {
+              "example": 10
+            }
+          },
+          "plurals": {
+            "other": "Il y a {{itemCount}} pommes dans le panier",
+            "one": "il y a {{itemCount}} pomme dans le panier",
+            "zero": "le panier est vide"
+          }
+        }
+      }
+    }
+  },
+  "exported_at": "2022-06-15T14:03:42.562Z"
+}

--- a/example/src/ditto/index.js
+++ b/example/src/ditto/index.js
@@ -7,6 +7,20 @@ module.exports = {
         "otherText": {
           "text_61e7238bbae5dc00fb66de01": {
             "text": "You ordered {{itemCount}} apples",
+            "variants": {
+              "french": {
+                "text": "Vous avez commandé {{itemCount}} pommes",
+                "variables": {
+                  "itemCount": {
+                    "example": 10
+                  }
+                },
+                "plurals": {
+                  "other": "Vous avez commandé {{itemCount}} pommes",
+                  "one": "Vous avez commandé {{itemCount}} pomme"
+                }
+              }
+            },
             "status": "REVIEW",
             "variables": {
               "itemCount": {
@@ -20,6 +34,21 @@ module.exports = {
           },
           "text_61e7238bbae5dc00fb66de0b": {
             "text": "There are  {{itemCount}} items in the cart",
+            "variants": {
+              "french": {
+                "text": "Il y a {{itemCount}} pommes dans le panier",
+                "variables": {
+                  "itemCount": {
+                    "example": 10
+                  }
+                },
+                "plurals": {
+                  "other": "Il y a {{itemCount}} pommes dans le panier",
+                  "one": "il y a {{itemCount}} pomme dans le panier",
+                  "zero": "le panier est vide"
+                }
+              }
+            },
             "is_comp": true,
             "component_api_id": "shopping-cart",
             "variables": {
@@ -35,6 +64,20 @@ module.exports = {
           },
           "text_61e7238bbae5dc00fb66de15": {
             "text": "There are {{itemCount}} puppies",
+            "variants": {
+              "french": {
+                "text": "Il y a {{itemCount}} chiots",
+                "variables": {
+                  "itemCount": {
+                    "example": 10
+                  }
+                },
+                "plurals": {
+                  "other": "Il y a {{itemCount}} chiots",
+                  "one": "Il y a {{itemCount}} chiot"
+                }
+              }
+            },
             "variables": {
               "itemCount": {
                 "example": 10
@@ -52,9 +95,11 @@ module.exports = {
         "blocks": {
           "header": {
             "text_61e7238bbae5dc00fb66ddff": {
-              "text": "Welcome!",
+              "text": "Welcome!1",
               "variants": {
-                "french": "Bonjour!"
+                "french": {
+                  "text": "Bonjour!"
+                }
               }
             },
             "text_61e7238bbae5dc00fb66de09": {
@@ -92,7 +137,9 @@ module.exports = {
           "text_61e7238bbae5dc00fb66de2c": {
             "text": "Next",
             "variants": {
-              "french": "Prochaine"
+              "french": {
+                "text": "Prochaine"
+              }
             }
           }
         }
@@ -227,6 +274,79 @@ module.exports = {
             "text": "<- Back"
           }
         }
+      },
+      "frame_61f02da85e52b60129977c37": {
+        "frameName": "Frame 2",
+        "blocks": {},
+        "otherText": {
+          "text_61f02da85e52b60129977c3b": {
+            "text": "xzcv"
+          }
+        }
+      }
+    },
+    "french": {
+      "frame_61e7238bbae5dc00fb66ddf5": {
+        "frameName": "Plurals",
+        "blocks": {},
+        "otherText": {
+          "text_61e7238bbae5dc00fb66de01": {
+            "text": "Vous avez commandé {{itemCount}} pommes",
+            "status": "REVIEW",
+            "variables": {
+              "itemCount": {
+                "example": 10
+              }
+            },
+            "plurals": {
+              "other": "Vous avez commandé {{itemCount}} pommes",
+              "one": "Vous avez commandé {{itemCount}} pomme"
+            }
+          },
+          "text_61e7238bbae5dc00fb66de0b": {
+            "text": "Il y a {{itemCount}} pommes dans le panier",
+            "is_comp": true,
+            "component_api_id": "shopping-cart",
+            "variables": {
+              "itemCount": {
+                "example": 10
+              }
+            },
+            "plurals": {
+              "other": "Il y a {{itemCount}} pommes dans le panier",
+              "one": "il y a {{itemCount}} pomme dans le panier",
+              "zero": "le panier est vide"
+            }
+          },
+          "text_61e7238bbae5dc00fb66de15": {
+            "text": "Il y a {{itemCount}} chiots",
+            "variables": {
+              "itemCount": {
+                "example": 10
+              }
+            },
+            "plurals": {
+              "other": "Il y a {{itemCount}} chiots",
+              "one": "Il y a {{itemCount}} chiot"
+            }
+          }
+        }
+      },
+      "frame_61e7238bbae5dc00fb66ddf1": {
+        "frameName": "Welcome",
+        "blocks": {
+          "header": {
+            "text_61e7238bbae5dc00fb66ddff": {
+              "text": "Bonjour!"
+            }
+          },
+          "cta": {}
+        },
+        "otherText": {
+          "text_61e7238bbae5dc00fb66de2c": {
+            "text": "Prochaine"
+          }
+        }
       }
     }
   },
@@ -244,11 +364,42 @@ module.exports = {
           "other": "There are  {{itemCount}} items in the cart",
           "one": "There is  {{itemCount}} item in the cart",
           "zero": "The cart is empty"
+        },
+        "variants": {
+          "french": {
+            "text": "Il y a {{itemCount}} pommes dans le panier",
+            "variables": {
+              "itemCount": {
+                "example": 10
+              }
+            },
+            "plurals": {
+              "other": "Il y a {{itemCount}} pommes dans le panier",
+              "one": "il y a {{itemCount}} pomme dans le panier",
+              "zero": "le panier est vide"
+            }
+          }
         }
       },
       "team-plan": {
         "name": "Team Plan",
         "text": "Our Team Plan includes everything in the Basic Plan, in addition to unlimited messages between members of your workspace."
+      }
+    },
+    "french": {
+      "shopping-cart": {
+        "name": "Shopping Cart",
+        "text": "Il y a {{itemCount}} pommes dans le panier",
+        "variables": {
+          "itemCount": {
+            "example": 10
+          }
+        },
+        "plurals": {
+          "other": "Il y a {{itemCount}} pommes dans le panier",
+          "one": "il y a {{itemCount}} pomme dans le panier",
+          "zero": "le panier est vide"
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ditto-react",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "React SDK for using product copy from Ditto in development.",
   "author": "Ditto Tech Inc.",
   "license": "MIT",

--- a/src/components/DittoProvider.tsx
+++ b/src/components/DittoProvider.tsx
@@ -1,26 +1,19 @@
-import React, { useMemo } from "react";
-import {
-  DittoContext,
-  DittoOptions,
-  DittoSource,
-  Source,
-} from "../lib/context";
+import React from "react";
+import { DittoContext, DittoSource } from "../lib/context";
 
 interface DittoProviderProps {
   projectId?: string;
   variant?: string;
   source: DittoSource;
   children: React.ReactNode;
-  options?: DittoOptions;
 }
 
 export const DittoProvider = (props: DittoProviderProps) => {
-  const { children, source, variant, projectId, options } = props;
+  const { children, source, variant, projectId } = props;
 
   return (
     <DittoContext.Provider
       value={{
-        options,
         source,
         variant,
         ...(projectId ? { projectId } : {}),

--- a/src/hooks/useDitto.ts
+++ b/src/hooks/useDitto.ts
@@ -15,7 +15,7 @@ interface useDittoProps {
 
 export const useDitto = (props: useDittoProps) => {
   const { projectId, frameId, blockId, filters, variables, count } = props;
-  const { source, variant, options } = useContext(DittoContext);
+  const { source, variant } = useContext(DittoContext);
 
   if (!projectId) return nullError("No Project ID provided.");
 

--- a/src/hooks/useDitto.ts
+++ b/src/hooks/useDitto.ts
@@ -35,12 +35,6 @@ export const useDitto = (props: useDittoProps) => {
         }
       }
     }
-
-    if (options?.environment !== "production") {
-      const message = `Text not found for frameId: "${frameId}", blockId: "${blockId}"`;
-      console.error(message);
-      return message;
-    }
   }
 
   const data = source[projectId]?.base;

--- a/src/hooks/useDittoComponent.ts
+++ b/src/hooks/useDittoComponent.ts
@@ -34,12 +34,6 @@ export const useDittoComponent = (props: Args): DittoComponent => {
         return data[componentId];
       }
     }
-
-    if (options?.environment !== "production") {
-      const message = `Text not found for componentId: "${componentId}"`;
-      console.error(message);
-      return message;
-    }
   }
 
   const data = source?.ditto_component_library?.base;

--- a/src/hooks/useDittoComponent.ts
+++ b/src/hooks/useDittoComponent.ts
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 import { DittoContext, SourceDetector, VariablesInput } from "../lib/context";
-import { nullError, interpolateVariableText} from "../lib/utils";
+import { nullError, interpolateVariableText } from "../lib/utils";
 
 type DittoComponentString = string;
 type DittoComponentObject = {
@@ -17,7 +17,7 @@ interface Args {
 
 export const useDittoComponent = (props: Args): DittoComponent => {
   const { componentId, alwaysReturnString, variables, count } = props;
-  const { source, variant, options } = useContext(DittoContext);
+  const { source, variant } = useContext(DittoContext);
   if (!("ditto_component_library" in source)) {
     throw new Error(
       "An export file for the Component Library couldn't be found."
@@ -28,7 +28,11 @@ export const useDittoComponent = (props: Args): DittoComponent => {
     const data = source?.ditto_component_library?.[variant];
     if (data && data[componentId]) {
       if (SourceDetector.isStructured(data)) {
-        const value = interpolateVariableText(data[componentId], variables, count)
+        const value = interpolateVariableText(
+          data[componentId],
+          variables,
+          count
+        );
         return alwaysReturnString ? value.text : value;
       } else if (SourceDetector.isFlat(data)) {
         return data[componentId];
@@ -45,10 +49,9 @@ export const useDittoComponent = (props: Args): DittoComponent => {
     return nullError(`Text not found for component "${componentId}"`);
   }
 
-
   if (SourceDetector.isStructured(data)) {
     const value = interpolateVariableText(data[componentId], variables, count);
-    return alwaysReturnString ? value.text :value;
+    return alwaysReturnString ? value.text : value;
   } else if (SourceDetector.isFlat(data)) {
     return data[componentId];
   } else {

--- a/src/hooks/useDittoSingleText.ts
+++ b/src/hooks/useDittoSingleText.ts
@@ -1,5 +1,10 @@
 import { useContext } from "react";
-import { DittoContext, SourceDetector, VariablesInput, Count } from "../lib/context";
+import {
+  DittoContext,
+  SourceDetector,
+  VariablesInput,
+  Count,
+} from "../lib/context";
 import { nullError, interpolateVariableText } from "../lib/utils";
 
 interface useDittoSingleTextProps {
@@ -11,20 +16,19 @@ interface useDittoSingleTextProps {
 
 export const useDittoSingleText = (props: useDittoSingleTextProps) => {
   const { projectId, textId, variables, count } = props;
-  const { source, variant, options } = useContext(DittoContext);
+  const { source, variant } = useContext(DittoContext);
 
   if (!projectId) return nullError("No Project ID provided.");
 
   if (variant) {
     const data = source?.[projectId]?.[variant];
     if (data) {
-
       if (SourceDetector.isStructured(data)) {
         return interpolateVariableText(data[textId], variables, count).text;
       }
 
       if (SourceDetector.isFlat(data)) {
-        return data[textId]
+        return data[textId];
       }
 
       if (SourceDetector.isFrame(data)) {
@@ -34,11 +38,17 @@ export const useDittoSingleText = (props: useDittoSingleTextProps) => {
           for (const blockId in frame.blocks) {
             const block = frame.blocks[blockId];
 
-            if (textId in block) return interpolateVariableText(block[textId], variables, count).text;
+            if (textId in block)
+              return interpolateVariableText(block[textId], variables, count)
+                .text;
           }
 
           if (frame.otherText && textId in frame.otherText)
-            return interpolateVariableText(frame.otherText[textId], variables, count).text;
+            return interpolateVariableText(
+              frame.otherText[textId],
+              variables,
+              count
+            ).text;
         }
       }
     }
@@ -64,11 +74,16 @@ export const useDittoSingleText = (props: useDittoSingleTextProps) => {
       for (const blockId in frame.blocks) {
         const block = frame.blocks[blockId];
 
-        if (textId in block) return interpolateVariableText(block[textId], variables, count).text;
+        if (textId in block)
+          return interpolateVariableText(block[textId], variables, count).text;
       }
 
       if (frame.otherText && textId in frame.otherText)
-        return interpolateVariableText(frame.otherText[textId], variables, count).text;
+        return interpolateVariableText(
+          frame.otherText[textId],
+          variables,
+          count
+        ).text;
     }
   }
 

--- a/src/hooks/useDittoSingleText.ts
+++ b/src/hooks/useDittoSingleText.ts
@@ -42,12 +42,6 @@ export const useDittoSingleText = (props: useDittoSingleTextProps) => {
         }
       }
     }
-
-    if (options?.environment !== "production") {
-      const message = `Text not found for textId: "${textId}"`;
-      console.error(message);
-      return message;
-    }
   }
 
   const data = source?.[projectId]?.base;

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,28 +1,26 @@
 import { createContext } from "react";
 import { Plurals } from "../components/Ditto";
 
-
-
-export type Count = number | undefined
+export type Count = number | undefined;
 
 export interface VariableData {
   text?: string;
-  url?: string
+  url?: string;
   example?: string;
   fallback?: string;
 }
 
-type VariableType = string | number
+type VariableType = string | number;
 export interface VariablesInput {
-  [variableId: string]: VariableType
+  [variableId: string]: VariableType;
 }
 
-export interface TextData  {
+export interface TextData {
   plurals: Plurals;
   text: string;
   variables: {
     [variableName: string]: VariableData;
-  }
+  };
 }
 
 export interface Block {
@@ -140,15 +138,10 @@ export const SourceDetector = {
   },
 };
 
-export interface DittoOptions {
-  environment?: "development" | "staging" | "production";
-}
-
 interface DittoContext {
   projectId?: string;
   variant?: string;
   source: DittoSource;
-  options?: DittoOptions;
 }
 
 export const DittoContext = createContext({} as DittoContext);


### PR DESCRIPTION
**Overview:**
- library already supports variants plurals/variables
- remove variant warning messages for local builds
- update test project to test switching between projects

**Context:**
https://linear.app/dittowords/issue/DIT-1512/update-ditto-react-to-support-variant-variablesplurals

**Screenshots:**
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/7476817/173848329-41a6172a-0dce-4b45-aa7d-b80ddb0ed1e6.png">
<img width="1242" alt="image" src="https://user-images.githubusercontent.com/7476817/173848404-fa22d74c-bf89-45a0-8e17-2fe41bb26716.png">
<img width="978" alt="image" src="https://user-images.githubusercontent.com/7476817/173848490-7a41e57e-9aba-4d86-ba05-6f36bb5500a9.png">

**Test Plan:**
- [ ]  run `yarn start`
- [ ] in another window run `cd example && yarn start`
- [ ] example project should open up
- [ ] switch to the 'french' variant, confirm each `ditto-react` component renders with the expected text