### PR TITLE
Export internal hooks for public usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,15 @@ const App = () => {
 
 ## Interpolation
 
-Support dynamic text by passing in variables into your text:
+Support dynamic text by specifying variables:
 
 ```jsx
 <Ditto textId={textId} />
-// The cart contains {{itemCount}} {{itemName}}
-<Ditto textId={textId} variables={{ itemName: "apples", itemCount: 10 }}/>
-// The cart contains 10 apples
-<Ditto textId={textId} variables={{ itemName: "pears", itemCount: 6 }}/>
-// The cart contains 6 pears
+// The cart contains {{itemName}}
+<Ditto textId={textId} variables={{ itemName: "apples" }}/>
+// The cart contains apples
+<Ditto textId={textId} variables={{ itemName: "pears" }}/>
+// The cart contains pears
 ```
 
 Learn how to configure Ditto variables: https://www.dittowords.com/docs/variables
@@ -113,7 +113,7 @@ Ditto pluralization can be utilized by passing in the `count` prop:
 ```jsx
 <Ditto textId={textId}/> // The cart contains {{numItems}} items
 <Ditto textId={textId} variables={{ numItems: 3 }} count={3}/> // The cart contains 3 items
-<Ditto textId={textId} variables={{ numItems: 1 }}count={1}/> // The cart contains 1 item
+<Ditto textId={textId} variables={{ numItems: 1 }} count={1}/> // The cart contains 1 item
 <Ditto textId={textId} variables={{ numItems: 0 }} count={0}/> // The cart contains no items
 ```
 
@@ -225,7 +225,7 @@ If you pass `frameId` and/or `blockId`, the specified frame/block object will be
 </Ditto>
 ```
 
-### Note
+### Type-specific component exports
 
 In addition to the `<Ditto />` component, individual exports of each specific component type are also available. These behave identically to passing the respective prop configurations to the `<Ditto />` component, but may provide a better experience for TypeScript users due to their improved out-of-the-box type safety and inference:
 
@@ -236,6 +236,19 @@ import {
   DittoText,
   DittoComponent, // rendering components from your Ditto component library
 } from "ditto-react";
+```
+
+### Hooks (experimental)
+
+Hooks are also available for consuming data from a `<DittoProvider />`. The two hooks currently exposed have unpolished ergonomics due to the manner in which they evolved from legacy constraints.
+
+In future versions of `ditto-react`, a hooks-based API will be the primary way through which data is accessed (instead of components), and the API will likely have some differences from what is currently available.
+
+```js
+import { useDittoComponent, useDittoSingleText } from "ditto-react";
+
+const componentText = useDittoComponent({ componentId: "xxx-xxx" });
+const text = useDittoSingleText({ textId: "xxx-xxx" }); // assumes `projectId` was specified for an ancestor <DittoProvider />
 ```
 
 ## Additional Examples

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState } from "react";
 import DittoProvider, {
   Ditto,
   Frame,
@@ -7,258 +7,341 @@ import DittoProvider, {
   DittoFrame,
   DittoBlock,
   DittoComponent,
+  useDittoComponent,
+  useDittoSingleText,
 } from "ditto-react";
 import source from "./ditto";
 
-const App = () => {
-  const options = ['base', 'french']
-  const [variant, setVariant] = useState<string>('base')
-  const onVariantChange = (e: any) => {
-    setVariant(e.target.value)
-  }
+const variantOptions = ["base", "french"] as const;
+type Variant = typeof variantOptions[number];
+
+interface AppProps {
+  onVariantChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+}
+
+const PROJECT_ID = "project_61e72388365c930170607378";
+
+const AppWrapper = () => {
+  const [variant, setVariant] = useState<Variant>("base");
+  const onVariantChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value as Variant;
+    setVariant(value);
+  };
+
+  return (
+    <DittoProvider source={source} projectId={PROJECT_ID} variant={variant}>
+      <App onVariantChange={onVariantChange} />
+    </DittoProvider>
+  );
+};
+
+const App = (props: AppProps) => {
+  const { onVariantChange } = props;
+
+  const componentHookTextNoVariables = useDittoComponent({
+    componentId: "shopping-cart",
+  });
+
+  const componentHookTextWithVariables = useDittoComponent({
+    componentId: "shopping-cart",
+    variables: { itemCount: 1 },
+    count: 1,
+  });
+
+  const singleTextHookNoVariables = useDittoSingleText({
+    textId: "text_61e7238bbae5dc00fb66de0b",
+  });
+
+  const singleTextHookWithVariables = useDittoSingleText({
+    textId: "text_61e7238bbae5dc00fb66de0b",
+    variables: { itemCount: 3 },
+    count: 3,
+  });
+
   return (
     <div style={{ padding: 40 }}>
       <select onChange={onVariantChange}>
-        {options.map(option => (
-          <option key={option} value={option}>{option}</option>
+        {variantOptions.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
         ))}
       </select>
       <div>
-        <DittoProvider
-          source={source}
-          projectId="project_61e72388365c930170607378"
-          variant={variant}
-        >
-          <h4>Component Libary</h4>
+        <h4>Component Libary</h4>
+        <div>
+          <h5>ShoppingCart</h5>
           <div>
-            <h5>ShoppingCart</h5>
-            <div>
-              <div className="dittoItem">
-                <pre>{`<Ditto componentId="shopping-cart" />`}</pre>
-                <Ditto componentId="shopping-cart" />
-              </div>
-              <div className="dittoItem">
-                <pre>{`<Ditto componentId="shopping-cart" variables={{ itemCount: 2 }}/>`}</pre>
-                <Ditto componentId="shopping-cart" variables={{ itemCount: 2 }}/>
-              </div>
-              <div className="dittoItem">
-                <pre>{`<Ditto componentId="shopping-cart" count={2}/>`}</pre>
-                <Ditto componentId="shopping-cart" count={2}/>
-              </div>
-              <div className="dittoItem">
-                <pre>{`<Ditto componentId="shopping-cart" count={0} variables={{ itemCount: 0 }}/>`}</pre>
-                <Ditto componentId="shopping-cart" count={0} variables={{ itemCount: 0 }}/>
-              </div>
-              <div className="dittoItem">
-                <pre>{`<Ditto componentId="shopping-cart" count={1} variables={{ itemCount: 1 }}/>`}</pre>
-                <Ditto componentId="shopping-cart" count={1} variables={{ itemCount: 1 }}/>
-              </div>
-              <div className="dittoItem">
-                <pre>{`<Ditto componentId="shopping-cart" count={5} variables={{ itemCount: 5 }}/>`}</pre>
-                <Ditto componentId="shopping-cart" count={5} variables={{ itemCount: 5 }}/>
-              </div>
+            <div className="dittoItem">
+              <pre>{`useDittoComponent({ componentId: "shopping-cart" });`}</pre>
+              <div>{componentHookTextNoVariables}</div>
+            </div>
+            <div className="dittoItem">
+              <pre>{`useDittoComponent({ componentId: "shopping-cart", variables: { itemCount: 1 }, count: 1 });`}</pre>
+              <div>{componentHookTextWithVariables}</div>
+            </div>
+            <div className="dittoItem">
+              <pre>{`useDittoSingleText({ textId: "text_61e7238bbae5dc00fb66de0b" });`}</pre>
+              <div>{singleTextHookNoVariables}</div>
+            </div>
+            <div className="dittoItem">
+              <pre>{`useDittoSingleText({ textId: "text_61e7238bbae5dc00fb66de0b", variables: { itemCount: 3 }, count: 3 });`}</pre>
+              <div>{singleTextHookWithVariables}</div>
+            </div>
+            <div className="dittoItem">
+              <pre>{`<Ditto componentId="shopping-cart" />`}</pre>
+              <Ditto componentId="shopping-cart" />
+            </div>
+            <div className="dittoItem">
+              <pre>{`<Ditto componentId="shopping-cart" variables={{ itemCount: 2 }}/>`}</pre>
+              <Ditto componentId="shopping-cart" variables={{ itemCount: 2 }} />
+            </div>
+            <div className="dittoItem">
+              <pre>{`<Ditto componentId="shopping-cart" count={2}/>`}</pre>
+              <Ditto componentId="shopping-cart" count={2} />
+            </div>
+            <div className="dittoItem">
+              <pre>{`<Ditto componentId="shopping-cart" count={0} variables={{ itemCount: 0 }}/>`}</pre>
+              <Ditto
+                componentId="shopping-cart"
+                count={0}
+                variables={{ itemCount: 0 }}
+              />
+            </div>
+            <div className="dittoItem">
+              <pre>{`<Ditto componentId="shopping-cart" count={1} variables={{ itemCount: 1 }}/>`}</pre>
+              <Ditto
+                componentId="shopping-cart"
+                count={1}
+                variables={{ itemCount: 1 }}
+              />
+            </div>
+            <div className="dittoItem">
+              <pre>{`<Ditto componentId="shopping-cart" count={5} variables={{ itemCount: 5 }}/>`}</pre>
+              <Ditto
+                componentId="shopping-cart"
+                count={5}
+                variables={{ itemCount: 5 }}
+              />
             </div>
           </div>
-          <div>
-           
+        </div>
+        <div>
           <h5>teamplan</h5>
           <div>
             <div className="dittoItem">
               <pre>{`<DittoComponent componentId="team-plan" />`}</pre>
               <DittoComponent componentId="team-plan" />
-            </div> 
-          </div>
-          </div>
-          <h4>Project</h4>
-          <div>    
-            <div className="dittoItem">
-              <pre>{`<Ditto frameId="frame_61e7238bbae5dc00fb66ddf5">`}</pre>
-              <Ditto frameId="frame_61e7238bbae5dc00fb66ddf5">
-                {(frame: Frame) => {
-                  const markup: React.ReactNode[] = [];
-
-                  Object.keys(frame.blocks).forEach((blockId) => {
-                    const block: Block = frame.blocks[blockId];
-
-                    Object.keys(block).forEach((textId) => {
-                      markup.push(
-                        <div key={`${blockId}-${textId}`} >
-                          {block[textId]}
-                        </div>
-                      );
-                    });
-                  });
-
-                  return markup;
-                }}
-              </Ditto>
-            </div>
-            <div className="dittoItem">
-              <pre>{`<Ditto frameId="frame_61e7238bbae5dc00fb66ddf1" variables={{ email: "support@example.com", minutes: 10 }}>`}</pre>
-              <Ditto frameId="frame_61e7238bbae5dc00fb66ddf1" variables={{ email: "support@example.com", minutes: 10 }}>
-                {(frame: Frame) => {
-                  const markup: React.ReactNode[] = [];
-
-                  Object.keys(frame.blocks).forEach((blockId) => {
-                    const block: Block = frame.blocks[blockId];
-
-                    Object.keys(block).forEach((textId) => {
-                      markup.push(
-                        <div key={`${blockId}-${textId}`} >
-                          {block[textId]}
-                        </div>
-                      );
-                    });
-                  });
-
-                  return markup;
-                }}
-              </Ditto>
-            </div>
-            <div className="dittoItem">
-              <pre>{`<Ditto frameId="frame_61e7238bbae5dc00fb66ddf1" variables={{ email: "support@example.com", minutes: 1 }} count={1}>`}</pre>
-              <Ditto frameId="frame_61e7238bbae5dc00fb66ddf1" variables={{ email: "support@example.com", minutes: 1 }} count={1}>
-                {(frame: Frame) => {
-                  const markup: React.ReactNode[] = [];
-
-                  Object.keys(frame.blocks).forEach((blockId) => {
-                    const block: Block = frame.blocks[blockId];
-
-                    Object.keys(block).forEach((textId) => {
-                      markup.push(
-                        <div key={`${blockId}-${textId}`} >
-                          {block[textId]}
-                        </div>
-                      );
-                    });
-                  });
-
-                  return markup;
-                }}
-              </Ditto>
-            </div>
-            <div className="dittoItem">
-              <pre>{`<DittoFrame frameId="frame_61e7238bbae5dc00fb66ddf2">`}</pre>
-              <DittoFrame frameId="frame_61e7238bbae5dc00fb66ddf2">
-                {(frame) => {
-                  const markup: React.ReactNode[] = [];
-
-                  Object.keys(frame.blocks).forEach((blockId) => {
-                    const block: Block = frame.blocks[blockId];
-
-                    Object.keys(block).forEach((textId) => {
-                      markup.push(
-                        <div key={`${blockId}-${textId}`}>
-                          {block[textId]}
-                        </div>
-                      );
-                    });
-                  });
-                  return markup;
-                }}
-              </DittoFrame>
-            </div>
-            <div className="dittoItem">
-              <pre>{`<DittoFrame frameId="frame_61e7238bbae5dc00fb66ddf2" variables={{ planName: "Team", stepNumber: 3, totalSteps: 5 }}>`}</pre>
-              <DittoFrame frameId="frame_61e7238bbae5dc00fb66ddf2" variables={{ planName: "Team", stepNumber: 3, totalSteps: 5 }}>
-                {(frame) => {
-                  const markup: React.ReactNode[] = [];
-
-                  Object.keys(frame.blocks).forEach((blockId) => {
-                    const block: Block = frame.blocks[blockId];
-
-                    Object.keys(block).forEach((textId) => {
-                      markup.push(
-                        <div key={`${blockId}-${textId}`}>
-                          {block[textId]}
-                        </div>
-                      );
-                    });
-                  });
-                  return markup;
-                }}
-              </DittoFrame>
-            </div>
-            <div className="dittoItem">
-              <pre>{`<DittoBlock frameId="frame_61e7238bbae5dc00fb66ddf2" blockId="header"> `}</pre>
-              <DittoBlock
-                frameId="frame_61e7238bbae5dc00fb66ddf2"
-                blockId="header"
-              >
-                {(block) => {
-                  return Object.keys(block).map((key) => (
-                    <div key={key}>{block[key]}</div>
-                  ));
-                }}
-              </DittoBlock>
-            </div>
-            <div className="dittoItem">
-              <pre>{`<DittoBlock frameId="frame_61e7238bbae5dc00fb66ddf2" blockId="header" variables={{ stepNumber: 1, totalSteps: 9 }}> `}</pre>
-              <DittoBlock
-                frameId="frame_61e7238bbae5dc00fb66ddf2"
-                blockId="header"
-                variables={{ stepNumber: 1, totalSteps: 9 }}
-              >
-                {(block) => {
-                  return Object.keys(block).map((key) => (
-                    <div key={key}>{block[key]}</div>
-                  ));
-                }}
-              </DittoBlock>
-            </div>
-            <div className="dittoItem">
-              <pre>{`<DittoBlock frameId="frame_61e7238bbae5dc00fb66ddf2" blockId="header" variables={{ stepNumber: 1, totalSteps: 9 }} count={1}>`}</pre>
-              <DittoBlock
-                frameId="frame_61e7238bbae5dc00fb66ddf2"
-                blockId="header"
-                variables={{ stepNumber: 1, totalSteps: 9 }}
-                count={1}
-              >
-                {(block) => {
-                  return Object.keys(block).map((key) => (
-                    <div key={key}>{block[key]}</div>
-                  ));
-                }}
-              </DittoBlock>
-            </div>
-            <div className="dittoItem">
-              <pre>{`<Ditto textId="text_61e7238bbae5dc00fb66de0b" />`}</pre>
-              <Ditto textId="text_61e7238bbae5dc00fb66de0b" />
-            </div>
-            <div className="dittoItem">
-              <pre>{`<Ditto textId="text_61e7238bbae5dc00fb66de0b" variables={{ itemCount: 3 }}/>`}</pre>
-              <Ditto textId="text_61e7238bbae5dc00fb66de0b" variables={{ itemCount: 3 }}/>
-            </div>
-            <div className="dittoItem">
-              <pre>{`<Ditto textId="text_61e7238bbae5dc00fb66de0b" variables={{ itemCount: 1 }} count={1}/>`}</pre>
-              <Ditto textId="text_61e7238bbae5dc00fb66de0b" variables={{ itemCount: 1 }} count={1}/>
-            </div>
-            <div className="dittoItem">
-              <pre>{`<Ditto textId="text_61e7238bbae5dc00fb66de0b" variables={{ itemCount: 0 }} count={0}/>`}</pre>
-              <Ditto textId="text_61e7238bbae5dc00fb66de0b" variables={{ itemCount: 0 }} count={0}/>
-            </div>
-
-            <div className="dittoItem">
-              <pre>{`<DittoText textId="text_61e7238bbae5dc00fb66de15" />`}</pre>
-              <DittoText textId="text_61e7238bbae5dc00fb66de15" />
-            </div>
-            <div className="dittoItem">
-              <pre>{`<Ditto textId="text_61e7238bbae5dc00fb66de15" variables={{ itemCount: 10 }} count={0}/>`}</pre>
-              <Ditto textId="text_61e7238bbae5dc00fb66de15" variables={{ itemCount: 10 }} count={0}/>
-            </div>
-            <div className="dittoItem">
-              <pre>{`<DittoText textId="text_61e7238bbae5dc00fb66de15" variables={{ itemCount: 5 }}/>`}</pre>
-              <DittoText textId="text_61e7238bbae5dc00fb66de15" variables={{ itemCount: 5 }} />
-            </div>
-            <div className="dittoItem">
-              <pre>{`<DittoText textId="text_61e7238bbae5dc00fb66ddff"/>`}</pre>
-              <DittoText textId="text_61e7238bbae5dc00fb66ddff" />
             </div>
           </div>
-        </DittoProvider>
+        </div>
+        <h4>Project</h4>
+        <div>
+          <div className="dittoItem">
+            <pre>{`<Ditto frameId="frame_61e7238bbae5dc00fb66ddf5">`}</pre>
+            <Ditto frameId="frame_61e7238bbae5dc00fb66ddf5">
+              {(frame: Frame) => {
+                const markup: React.ReactNode[] = [];
+
+                Object.keys(frame.blocks).forEach((blockId) => {
+                  const block: Block = frame.blocks[blockId];
+
+                  Object.keys(block).forEach((textId) => {
+                    markup.push(
+                      <div key={`${blockId}-${textId}`}>{block[textId]}</div>
+                    );
+                  });
+                });
+
+                return markup;
+              }}
+            </Ditto>
+          </div>
+          <div className="dittoItem">
+            <pre>{`<Ditto frameId="frame_61e7238bbae5dc00fb66ddf1" variables={{ email: "support@example.com", minutes: 10 }}>`}</pre>
+            <Ditto
+              frameId="frame_61e7238bbae5dc00fb66ddf1"
+              variables={{ email: "support@example.com", minutes: 10 }}
+            >
+              {(frame: Frame) => {
+                const markup: React.ReactNode[] = [];
+
+                Object.keys(frame.blocks).forEach((blockId) => {
+                  const block: Block = frame.blocks[blockId];
+
+                  Object.keys(block).forEach((textId) => {
+                    markup.push(
+                      <div key={`${blockId}-${textId}`}>{block[textId]}</div>
+                    );
+                  });
+                });
+
+                return markup;
+              }}
+            </Ditto>
+          </div>
+          <div className="dittoItem">
+            <pre>{`<Ditto frameId="frame_61e7238bbae5dc00fb66ddf1" variables={{ email: "support@example.com", minutes: 1 }} count={1}>`}</pre>
+            <Ditto
+              frameId="frame_61e7238bbae5dc00fb66ddf1"
+              variables={{ email: "support@example.com", minutes: 1 }}
+              count={1}
+            >
+              {(frame: Frame) => {
+                const markup: React.ReactNode[] = [];
+
+                Object.keys(frame.blocks).forEach((blockId) => {
+                  const block: Block = frame.blocks[blockId];
+
+                  Object.keys(block).forEach((textId) => {
+                    markup.push(
+                      <div key={`${blockId}-${textId}`}>{block[textId]}</div>
+                    );
+                  });
+                });
+
+                return markup;
+              }}
+            </Ditto>
+          </div>
+          <div className="dittoItem">
+            <pre>{`<DittoFrame frameId="frame_61e7238bbae5dc00fb66ddf2">`}</pre>
+            <DittoFrame frameId="frame_61e7238bbae5dc00fb66ddf2">
+              {(frame) => {
+                const markup: React.ReactNode[] = [];
+
+                Object.keys(frame.blocks).forEach((blockId) => {
+                  const block: Block = frame.blocks[blockId];
+
+                  Object.keys(block).forEach((textId) => {
+                    markup.push(
+                      <div key={`${blockId}-${textId}`}>{block[textId]}</div>
+                    );
+                  });
+                });
+                return markup;
+              }}
+            </DittoFrame>
+          </div>
+          <div className="dittoItem">
+            <pre>{`<DittoFrame frameId="frame_61e7238bbae5dc00fb66ddf2" variables={{ planName: "Team", stepNumber: 3, totalSteps: 5 }}>`}</pre>
+            <DittoFrame
+              frameId="frame_61e7238bbae5dc00fb66ddf2"
+              variables={{ planName: "Team", stepNumber: 3, totalSteps: 5 }}
+            >
+              {(frame) => {
+                const markup: React.ReactNode[] = [];
+
+                Object.keys(frame.blocks).forEach((blockId) => {
+                  const block: Block = frame.blocks[blockId];
+
+                  Object.keys(block).forEach((textId) => {
+                    markup.push(
+                      <div key={`${blockId}-${textId}`}>{block[textId]}</div>
+                    );
+                  });
+                });
+                return markup;
+              }}
+            </DittoFrame>
+          </div>
+          <div className="dittoItem">
+            <pre>{`<DittoBlock frameId="frame_61e7238bbae5dc00fb66ddf2" blockId="header"> `}</pre>
+            <DittoBlock
+              frameId="frame_61e7238bbae5dc00fb66ddf2"
+              blockId="header"
+            >
+              {(block) => {
+                return Object.keys(block).map((key) => (
+                  <div key={key}>{block[key]}</div>
+                ));
+              }}
+            </DittoBlock>
+          </div>
+          <div className="dittoItem">
+            <pre>{`<DittoBlock frameId="frame_61e7238bbae5dc00fb66ddf2" blockId="header" variables={{ stepNumber: 1, totalSteps: 9 }}> `}</pre>
+            <DittoBlock
+              frameId="frame_61e7238bbae5dc00fb66ddf2"
+              blockId="header"
+              variables={{ stepNumber: 1, totalSteps: 9 }}
+            >
+              {(block) => {
+                return Object.keys(block).map((key) => (
+                  <div key={key}>{block[key]}</div>
+                ));
+              }}
+            </DittoBlock>
+          </div>
+          <div className="dittoItem">
+            <pre>{`<DittoBlock frameId="frame_61e7238bbae5dc00fb66ddf2" blockId="header" variables={{ stepNumber: 1, totalSteps: 9 }} count={1}>`}</pre>
+            <DittoBlock
+              frameId="frame_61e7238bbae5dc00fb66ddf2"
+              blockId="header"
+              variables={{ stepNumber: 1, totalSteps: 9 }}
+              count={1}
+            >
+              {(block) => {
+                return Object.keys(block).map((key) => (
+                  <div key={key}>{block[key]}</div>
+                ));
+              }}
+            </DittoBlock>
+          </div>
+          <div className="dittoItem">
+            <pre>{`<Ditto textId="text_61e7238bbae5dc00fb66de0b" />`}</pre>
+            <Ditto textId="text_61e7238bbae5dc00fb66de0b" />
+          </div>
+          <div className="dittoItem">
+            <pre>{`<Ditto textId="text_61e7238bbae5dc00fb66de0b" variables={{ itemCount: 3 }}/>`}</pre>
+            <Ditto
+              textId="text_61e7238bbae5dc00fb66de0b"
+              variables={{ itemCount: 3 }}
+            />
+          </div>
+          <div className="dittoItem">
+            <pre>{`<Ditto textId="text_61e7238bbae5dc00fb66de0b" variables={{ itemCount: 1 }} count={1}/>`}</pre>
+            <Ditto
+              textId="text_61e7238bbae5dc00fb66de0b"
+              variables={{ itemCount: 1 }}
+              count={1}
+            />
+          </div>
+          <div className="dittoItem">
+            <pre>{`<Ditto textId="text_61e7238bbae5dc00fb66de0b" variables={{ itemCount: 0 }} count={0}/>`}</pre>
+            <Ditto
+              textId="text_61e7238bbae5dc00fb66de0b"
+              variables={{ itemCount: 0 }}
+              count={0}
+            />
+          </div>
+
+          <div className="dittoItem">
+            <pre>{`<DittoText textId="text_61e7238bbae5dc00fb66de15" />`}</pre>
+            <DittoText textId="text_61e7238bbae5dc00fb66de15" />
+          </div>
+          <div className="dittoItem">
+            <pre>{`<Ditto textId="text_61e7238bbae5dc00fb66de15" variables={{ itemCount: 10 }} count={0}/>`}</pre>
+            <Ditto
+              textId="text_61e7238bbae5dc00fb66de15"
+              variables={{ itemCount: 10 }}
+              count={0}
+            />
+          </div>
+          <div className="dittoItem">
+            <pre>{`<DittoText textId="text_61e7238bbae5dc00fb66de15" variables={{ itemCount: 5 }}/>`}</pre>
+            <DittoText
+              textId="text_61e7238bbae5dc00fb66de15"
+              variables={{ itemCount: 5 }}
+            />
+          </div>
+          <div className="dittoItem">
+            <pre>{`<DittoText textId="text_61e7238bbae5dc00fb66ddff"/>`}</pre>
+            <DittoText textId="text_61e7238bbae5dc00fb66ddff" />
+          </div>
+        </div>
       </div>
     </div>
   );
 };
 
-export default App;
+export default AppWrapper;

--- a/src/components/Ditto.tsx
+++ b/src/components/Ditto.tsx
@@ -17,7 +17,7 @@ export type Plurals = {
 }
 
 export interface DittoFrameProps {
-  projectId?: string;
+  projectId?: string | null;
   frameId: string;
   variables?: VariablesInput;
   count?: number;
@@ -25,7 +25,7 @@ export interface DittoFrameProps {
 }
 
 export interface DittoBlockProps {
-  projectId?: string;
+  projectId?: string | null;
   frameId: string;
   blockId: string;
   variables?: VariablesInput;

--- a/src/components/DittoFrameOrBlock.tsx
+++ b/src/components/DittoFrameOrBlock.tsx
@@ -10,7 +10,7 @@ import {
 
 type Props = DittoFrameOrBlockProps;
 
-export const DittoFrameOrBlock = (props: Props) => {
+export const DittoFrameOrBlock = (props: Props): JSX.Element => {
   const { children, ...otherProps } = props;
   const data = useDitto(otherProps);
 

--- a/src/components/DittoText.tsx
+++ b/src/components/DittoText.tsx
@@ -6,11 +6,16 @@ import { DittoTextProps } from "./Ditto";
 export const DittoText = (props: DittoTextProps) => {
   const { textId, children, variables, count } = props;
   const projectId = useProjectId(props);
-  const text = useDittoSingleText({ projectId, textId, variables: variables || {}, count });
+  const text = useDittoSingleText({
+    projectId,
+    textId,
+    variables: variables || {},
+    count,
+  });
 
-  return (
-    <React.Fragment>
-      {typeof children === "function" ? children(text) : text}
-    </React.Fragment>
-  );
+  if (typeof text === "string" && typeof children === "function") {
+    return <>{children(text)}</>;
+  }
+
+  return <>{text}</>;
 };

--- a/src/hooks/useDitto.ts
+++ b/src/hooks/useDitto.ts
@@ -3,7 +3,7 @@ import { DittoContext, SourceDetector, VariablesInput } from "../lib/context";
 import { filterFrame, filterBlock, nullError } from "../lib/utils";
 
 interface useDittoProps {
-  projectId?: string;
+  projectId?: string | null;
   frameId: string;
   blockId?: string;
   variables?: VariablesInput;

--- a/src/hooks/useDittoComponent.ts
+++ b/src/hooks/useDittoComponent.ts
@@ -4,7 +4,7 @@ import { nullError, interpolateVariableText } from "../lib/utils";
 
 interface Args {
   componentId: string;
-  variables: VariablesInput;
+  variables?: VariablesInput;
   count?: number;
 }
 
@@ -21,7 +21,7 @@ export const useDittoComponent = (props: Args): string | null => {
     const data = source?.ditto_component_library?.[variant];
     if (data && data[componentId]) {
       if (SourceDetector.isStructured(data)) {
-        return interpolateVariableText(data[componentId], variables, count)
+        return interpolateVariableText(data[componentId], variables || {}, count)
           .text;
       } else if (SourceDetector.isFlat(data)) {
         return data[componentId];
@@ -39,7 +39,7 @@ export const useDittoComponent = (props: Args): string | null => {
   }
 
   if (SourceDetector.isStructured(data)) {
-    return interpolateVariableText(data[componentId], variables, count).text;
+    return interpolateVariableText(data[componentId], variables || {}, count).text;
   }
 
   if (SourceDetector.isFlat(data)) {

--- a/src/hooks/useDittoComponent.ts
+++ b/src/hooks/useDittoComponent.ts
@@ -2,21 +2,14 @@ import { useContext } from "react";
 import { DittoContext, SourceDetector, VariablesInput } from "../lib/context";
 import { nullError, interpolateVariableText } from "../lib/utils";
 
-type DittoComponentString = string;
-type DittoComponentObject = {
-  text: string;
-};
-type DittoComponent = DittoComponentString | DittoComponentObject;
-
 interface Args {
   componentId: string;
-  alwaysReturnString: boolean;
   variables: VariablesInput;
   count?: number;
 }
 
-export const useDittoComponent = (props: Args): DittoComponent => {
-  const { componentId, alwaysReturnString, variables, count } = props;
+export const useDittoComponent = (props: Args): string | null => {
+  const { componentId, variables, count } = props;
   const { source, variant } = useContext(DittoContext);
   if (!("ditto_component_library" in source)) {
     throw new Error(
@@ -28,12 +21,8 @@ export const useDittoComponent = (props: Args): DittoComponent => {
     const data = source?.ditto_component_library?.[variant];
     if (data && data[componentId]) {
       if (SourceDetector.isStructured(data)) {
-        const value = interpolateVariableText(
-          data[componentId],
-          variables,
-          count
-        );
-        return alwaysReturnString ? value.text : value;
+        return interpolateVariableText(data[componentId], variables, count)
+          .text;
       } else if (SourceDetector.isFlat(data)) {
         return data[componentId];
       }
@@ -50,11 +39,12 @@ export const useDittoComponent = (props: Args): DittoComponent => {
   }
 
   if (SourceDetector.isStructured(data)) {
-    const value = interpolateVariableText(data[componentId], variables, count);
-    return alwaysReturnString ? value.text : value;
-  } else if (SourceDetector.isFlat(data)) {
-    return data[componentId];
-  } else {
-    return nullError(`Invalid format for component ${componentId}`);
+    return interpolateVariableText(data[componentId], variables, count).text;
   }
+
+  if (SourceDetector.isFlat(data)) {
+    return data[componentId];
+  }
+
+  return nullError(`Invalid format for component ${componentId}`);
 };

--- a/src/hooks/useDittoSingleText.ts
+++ b/src/hooks/useDittoSingleText.ts
@@ -8,7 +8,7 @@ import {
 import { nullError, interpolateVariableText } from "../lib/utils";
 
 interface useDittoSingleTextProps {
-  projectId?: string;
+  projectId?: string | null;
   textId: string;
   variables: VariablesInput;
   count?: Count;

--- a/src/hooks/useDittoSingleText.ts
+++ b/src/hooks/useDittoSingleText.ts
@@ -14,7 +14,9 @@ interface useDittoSingleTextProps {
   count?: Count;
 }
 
-export const useDittoSingleText = (props: useDittoSingleTextProps) => {
+export const useDittoSingleText = (
+  props: useDittoSingleTextProps
+): string | null => {
   const { projectId, textId, variables, count } = props;
   const { source, variant } = useContext(DittoContext);
 
@@ -87,5 +89,5 @@ export const useDittoSingleText = (props: useDittoSingleTextProps) => {
     }
   }
 
-  return `Text not found for id "${textId}"`;
+  return nullError(`Text not found for id "${textId}"`);
 };

--- a/src/hooks/useDittoSingleText.ts
+++ b/src/hooks/useDittoSingleText.ts
@@ -5,28 +5,29 @@ import {
   VariablesInput,
   Count,
 } from "../lib/context";
-import { nullError, interpolateVariableText } from "../lib/utils";
+import { nullError, interpolateVariableText, useProjectId } from "../lib/utils";
 
 interface useDittoSingleTextProps {
   projectId?: string | null;
   textId: string;
-  variables: VariablesInput;
+  variables?: VariablesInput;
   count?: Count;
 }
 
 export const useDittoSingleText = (
   props: useDittoSingleTextProps
 ): string | null => {
-  const { projectId, textId, variables, count } = props;
+  const { textId, variables, count } = props;
   const { source, variant } = useContext(DittoContext);
 
+  const projectId = useProjectId(props);
   if (!projectId) return nullError("No Project ID provided.");
 
   if (variant) {
     const data = source?.[projectId]?.[variant];
     if (data) {
       if (SourceDetector.isStructured(data)) {
-        return interpolateVariableText(data[textId], variables, count).text;
+        return interpolateVariableText(data[textId], variables || {}, count).text;
       }
 
       if (SourceDetector.isFlat(data)) {
@@ -41,14 +42,14 @@ export const useDittoSingleText = (
             const block = frame.blocks[blockId];
 
             if (textId in block)
-              return interpolateVariableText(block[textId], variables, count)
+              return interpolateVariableText(block[textId], variables || {}, count)
                 .text;
           }
 
           if (frame.otherText && textId in frame.otherText)
             return interpolateVariableText(
               frame.otherText[textId],
-              variables,
+              variables || {},
               count
             ).text;
         }
@@ -62,7 +63,7 @@ export const useDittoSingleText = (
   }
 
   if (SourceDetector.isStructured(data)) {
-    return interpolateVariableText(data[textId], variables, count).text;
+    return interpolateVariableText(data[textId], variables || {}, count).text;
   }
 
   if (SourceDetector.isFlat(data)) {
@@ -77,13 +78,13 @@ export const useDittoSingleText = (
         const block = frame.blocks[blockId];
 
         if (textId in block)
-          return interpolateVariableText(block[textId], variables, count).text;
+          return interpolateVariableText(block[textId], variables || {}, count).text;
       }
 
       if (frame.otherText && textId in frame.otherText)
         return interpolateVariableText(
           frame.otherText[textId],
-          variables,
+          variables || {},
           count
         ).text;
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ export { DittoFrame, DittoBlock } from "./components/DittoFrameOrBlock";
 export { DittoText } from "./components/DittoText";
 
 export { useDittoSingleText } from "./hooks/useDittoSingleText";
-
+export { useDittoComponent } from "./hooks/useDittoComponent";
 
 export { DittoProvider };
 export default DittoProvider;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,5 +6,8 @@ export { DittoComponent } from "./components/DittoComponent";
 export { DittoFrame, DittoBlock } from "./components/DittoFrameOrBlock";
 export { DittoText } from "./components/DittoText";
 
+export { useDittoSingleText } from "./hooks/useDittoSingleText.ts";
+
+
 export { DittoProvider };
 export default DittoProvider;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ export { DittoComponent } from "./components/DittoComponent";
 export { DittoFrame, DittoBlock } from "./components/DittoFrameOrBlock";
 export { DittoText } from "./components/DittoText";
 
-export { useDittoSingleText } from "./hooks/useDittoSingleText.ts";
+export { useDittoSingleText } from "./hooks/useDittoSingleText";
 
 
 export { DittoProvider };

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -42,7 +42,7 @@ export function error(message: string, returnValue: any = message) {
 };
 
 export const nullError = (message: string): null => error(message, null);
-export const fragmentError = (message: string): React.ReactFragment => error(message, <Fragment />);
+export const fragmentError = (message: string): JSX.Element => error(message, <Fragment />);
 
 export const isProject = (
   props: DittoProps,
@@ -62,11 +62,11 @@ export const isFrameOrBlockComponent = (
   props: DittoProps
 ): props is DittoFrameOrBlockProps => "frameId" in props;
 
-export const useProjectId = (props: { projectId?: string }) => {
+export const useProjectId = (props: { projectId?: string | null }) => {
   const dittoContext = useContext(DittoContext);
   const projectId = dittoContext.projectId || props.projectId;
   if (!projectId) {
-    return fragmentError(
+    return nullError(
       "No Project ID was provided to the <DittoProvider /> or <Ditto /> components."
     );
   }

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -36,13 +36,13 @@ export const filterFrame = (_frameObj: Frame, variables: VariablesInput, count: 
   return { ...frameObj, otherText: filterBlock(frameObj.otherText, variables, count, filters) };
 };
 
-export const error = (message: string, returnValue: any = message) => {
+export function error(message: string, returnValue: any = message) {
   console.error(message);
   return returnValue;
 };
 
-export const nullError = (message: string) => error(message, null);
-export const fragmentError = (message: string) => error(message, <Fragment />);
+export const nullError = (message: string): null => error(message, null);
+export const fragmentError = (message: string): React.ReactFragment => error(message, <Fragment />);
 
 export const isProject = (
   props: DittoProps,


### PR DESCRIPTION
### Problem we faced

We needed to pass text from ditto into props of the components with the type `string`

And it wasn't an option since the only way to access the value was through React Component.


### Proposed solution

Make hook `useDittoSingleText` available for use.




-----------
### Hooks to expose
- [x] `useDittoSingleText`
- [x] `useDittoComponent`
~- [ ] `useDitto` (we may not actually want to expose this)~

### Other changes
- [x] Update README
- [x] Fix type definitions to ease direct use (without having to specify extra props e.g. by making `variables` required)