### PR TITLE
Change the npm install command example from a development dependency to dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Ditto also works with many popular 3rd party i18n libraries. Check out [our demo
 You can install `ditto-react` from npm:
 
 ```bash
-# as a dev dependency
-npm install --save-dev ditto-react
+npm install --save ditto-react
 ```
 
 `ditto-react` comes with TypeScript bindings out of the box.


### PR DESCRIPTION
This changes the instructions for the npm install to be a regular dependency rather than a development dependency. Since the exports here are react components we need them built with the rest of the regular dependencies to make it in the bundles.