### PR TITLE
[DIT-4325] Fix input being ignored when interpolating variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ditto-react",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "React SDK for using product copy from Ditto in development.",
   "author": "Ditto Tech Inc.",
   "license": "MIT",

--- a/src/lib/utils.tsx
+++ b/src/lib/utils.tsx
@@ -224,11 +224,11 @@ const getVariablePlaceholder = <V extends VariableData>(
   }
 
   if (variableData.__type === "number" || variableData.__type === "string") {
-    return String(variableData.example || variableData.fallback) || null;
+    return String(input || variableData.example || variableData.fallback) || null;
   }
 
   if (variableData.__type === "hyperlink") {
-    return variableData.text || input;
+    return  input || variableData.text;
   }
 
   if (variableData.__type === "map" && input) {


### PR DESCRIPTION
## Overview
Fixes https://github.com/dittowords/ditto-react/issues/30

Input values for variables are being ignored so example/fallback values are always being displayed.

## Test Plan
- [x] Verify providing variable values for a Ditto component results in the values being displayed. If the values are missing, then the example (or fallback) value should be displayed.